### PR TITLE
Reorder Steps for Building and Testing the Project

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,17 +18,17 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      - name: Check Formatting
-        run: pnpm prettier --check .
-
-      - name: Check Lint
-        run: pnpm eslint
-
       - name: Check Types
         run: pnpm tsc
 
       - name: Test App
         run: pnpm test
+
+      - name: Check Formatting
+        run: pnpm prettier --check .
+
+      - name: Check Lint
+        run: pnpm eslint
 
       - name: Build App
         run: pnpm vite build

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -9,12 +9,6 @@ pre-commit:
         - pnpm-lock.yaml
         - pnpm-workspace.yaml
 
-    - name: fix formatting
-      run: pnpm prettier --write --ignore-unknown {staged_files}
-
-    - name: fix lint
-      run: pnpm eslint --no-warn-ignored --fix {staged_files}
-
     - name: check types
       run: pnpm tsc
       glob:
@@ -22,6 +16,12 @@ pre-commit:
         - .npmrc
         - pnpm-lock.yaml
         - tsconfig.json
+
+    - name: fix formatting
+      run: pnpm prettier --write --ignore-unknown {staged_files}
+
+    - name: fix lint
+      run: pnpm eslint --no-warn-ignored --fix {staged_files}
 
     - name: check diff
       run: git diff --exit-code {staged_files}


### PR DESCRIPTION
This pull request resolves #422 by reordering the steps for building and testing the project in the CI workflow and pre-commit hook. The steps are now ordered so that type checks and tests are performed before formatting and linting.