### PR TITLE
Lock pnpm to Version 10

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
+        with:
+          version: 10.33.4
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
+        with:
+          version: 10.33.4
 
       - name: Install Dependencies
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -33,5 +33,6 @@
     "vite": "^7.3.2",
     "vitest": "^4.0.15",
     "vitest-browser-react": "^1.0.1"
-  }
+  },
+  "packageManager": "pnpm@10.33.4"
 }


### PR DESCRIPTION
This pull request resolves #585 by locking the pnpm version used in this project to version 10.33.4 in both the GitHub Actions workflows and `package.json`.